### PR TITLE
Spec 11 PR-1: Uniform poster ratio + remove stage badges from WorkGrid

### DIFF
--- a/apps/rfe-v0/components/WorkGrid.tsx
+++ b/apps/rfe-v0/components/WorkGrid.tsx
@@ -6,10 +6,11 @@ import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useLanguage } from './LanguageContext'
 import type { WorkItem, WorkCredit } from '@/lib/i18n/types'
-import { PRODUCTION_STAGE_LABELS, PRODUCTION_STAGE_TAB_LABELS } from '@/lib/i18n/types'
+import { PRODUCTION_STAGE_TAB_LABELS } from '@/lib/i18n/types'
 import type { ProductionStage } from '@/lib/i18n/types'
 import { useReveal, useStaggeredReveal } from '@/hooks/useReveal'
 import { getWorkSlug } from '@/lib/works'
+import { posterPreviewAspect } from '@rfe/design-tokens'
 
 export type WorkGridProps = {
   works: WorkItem[]
@@ -117,7 +118,6 @@ function WorkCard({
   previewsEnabled,
   cardRef,
   size,
-  hideStageBadge,
 }: {
   work: WorkItem
   delay: number
@@ -127,7 +127,6 @@ function WorkCard({
   previewsEnabled: boolean
   cardRef: (el: HTMLElement | null) => void
   size: ReturnType<typeof getMasonrySize>
-  hideStageBadge?: boolean
 }) {
   const { t, lang } = useLanguage()
   const reveal = useReveal({ delay })
@@ -214,12 +213,6 @@ function WorkCard({
     )
   }
 
-  const aspectRatio = size === 'full' ? '16/9'
-    : size === 'large' ? '2/3'
-    : size === 'medium' ? '3/4'
-    : '1/1'
-
-    
   return (
     <article
       ref={setRefs}
@@ -234,7 +227,7 @@ function WorkCard({
       >
         <div
           className="relative overflow-hidden mb-4 exhibition-frame cursor-pointer"
-          style={{ aspectRatio }}
+          style={{ aspectRatio: posterPreviewAspect }}
         >
           <div
             className={`absolute inset-0 transition-all duration-[1.2s] ${reveal.isVisible && !isHovered && !showPreview ? 'bw-media-scroll in-view' : isHovered || showPreview ? '' : 'bw-media'}`}
@@ -278,12 +271,6 @@ function WorkCard({
               mixBlendMode: 'overlay',
             }}
           />
-
-          {work.productionStage && !hideStageBadge && (
-            <span className="absolute top-2 left-2 z-[4] px-2 py-0.5 text-[10px] sm:text-xs uppercase tracking-wider font-medium bg-black/60 text-white/90 rounded-full backdrop-blur-sm">
-              {t.productionStage?.[work.productionStage] || PRODUCTION_STAGE_LABELS[work.productionStage]}
-            </span>
-          )}
 
           {/* Hover overlay */}
           <div className={`absolute inset-0 z-[5] bg-background/75 flex items-center justify-center transition-opacity duration-500 ${isHovered ? 'opacity-100' : 'opacity-0'} pointer-events-none`}>
@@ -539,7 +526,6 @@ export function WorkGrid({ works, tabField }: WorkGridProps) {
                 previewsEnabled={previewsEnabled}
                 cardRef={createCardRef(work.id)}
                 size={size}
-                hideStageBadge={showFilters}
               />
             </div>
           )

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,2 +1,2 @@
-export { colors, tones, easings, radius } from './tokens'
+export { colors, tones, easings, radius, posterPreviewAspect } from './tokens'
 export type { Colors, Tones, Easings } from './tokens'

--- a/packages/design-tokens/src/tokens.ts
+++ b/packages/design-tokens/src/tokens.ts
@@ -28,6 +28,9 @@ export const radius = {
   base: '0.25rem',
 } as const
 
+/** Theatrical one-sheet ratio for work list / scroll preview frames */
+export const posterPreviewAspect = '2/3' as const
+
 export type Colors = typeof colors
 export type Tones = typeof tones
 export type Easings = typeof easings

--- a/specs/11-uniform-poster-previews.md
+++ b/specs/11-uniform-poster-previews.md
@@ -1,0 +1,35 @@
+# Spec 11: Uniform Poster Previews
+
+## Context
+
+Work list previews use mixed aspect ratios (16/9, 2/3, 3/4, 1/1) in `WorkGrid` and `WorksScrollBlock`, which makes the site feel inconsistent. Production-stage badges ("In Production", etc.) duplicate information already shown in filter tabs.
+
+## Acceptance Criteria
+
+- [ ] All list/grid preview image frames use a single portrait ratio (`2/3`)
+- [ ] No `productionStage` overlay badges on `WorkGrid` cards
+- [ ] `WorksScrollBlock` scroll items use the same ratio (PR-2)
+- [ ] Filter tabs and genre tags under titles remain unchanged
+- [ ] Work detail hero (`aspect-video`) unchanged
+
+## API / Interface Contracts
+
+```ts
+// @rfe/design-tokens
+export const posterPreviewAspect = '2/3' as const
+```
+
+## File Structure
+
+```
+packages/design-tokens/src/tokens.ts
+apps/rfe-v0/components/WorkGrid.tsx
+apps/rfe-v0/components/blocks/WorksScrollBlock.tsx  (PR-2)
+```
+
+## Verification Checklist
+
+- [ ] `pnpm build` passes
+- [ ] Our Work + Development grids: uniform portrait frames, no stage pills
+- [ ] Horizontal works scroll: uniform portrait frames
+- [ ] Mobile (375px) and desktop (1440px) checked


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Spec 11 — PR-1 (Schema & frontend constants)

Implements acceptance criteria for uniform list preview frames and removal of production-stage overlay badges on grid cards.

### Changes
- Add `posterPreviewAspect` (`2/3`) to `@rfe/design-tokens`
- Apply single portrait ratio to all `WorkGrid` card image frames (replaces mixed 16/9, 2/3, 3/4, 1/1)
- Remove `productionStage` pills from grid previews (filter tabs unchanged)
- Spec: `specs/11-uniform-poster-previews.md`

### Verification
- [x] `pnpm --filter @rfe/v0 typecheck`
- PR-2 will align `WorksScrollBlock` to the same token

**Base:** `v2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c21b4afb-241d-4d4a-a066-55c5440660d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c21b4afb-241d-4d4a-a066-55c5440660d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

