### PR TITLE
Spec 11 PR-2: Uniform poster ratio for WorksScrollBlock

### DIFF
--- a/apps/rfe-v0/components/blocks/WorksScrollBlock.tsx
+++ b/apps/rfe-v0/components/blocks/WorksScrollBlock.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useReveal } from '@/hooks/useReveal'
 import { useLanguage } from '@/components/LanguageContext'
 import { useRef, useEffect, useState, useCallback, type PointerEvent as ReactPointerEvent } from 'react'
+import { posterPreviewAspect } from '@rfe/design-tokens'
 
 type ScrollItem = {
   work?: { title?: string; year?: number; poster?: { url?: string } | number; slug?: string } | number | null
@@ -353,8 +354,6 @@ export function WorksScrollComponent({ title, sourceType, selectedWorks, worksGr
                 const year = getYear(item)
                 const size = item.size || 'large'
                 const width = size === 'large' ? 'clamp(260px, 32vw, 400px)' : size === 'medium' ? 'clamp(200px, 24vw, 310px)' : 'clamp(140px, 16vw, 200px)'
-                const aspect = size === 'large' ? '3/4' : size === 'medium' ? '2/3' : '1/1'
-
                 return (
                   <div
                     key={i}
@@ -362,7 +361,7 @@ export function WorksScrollComponent({ title, sourceType, selectedWorks, worksGr
                     className={`relative shrink-0 snap-start group ${i === 0 ? 'pl-8' : i === displayItems.length - 1 ? 'pr-2' : ''}`}
                     style={{ width, marginTop: '2.5rem' }}
                   >
-                    <div className="relative overflow-hidden" style={{ aspectRatio: aspect }}>
+                    <div className="relative overflow-hidden" style={{ aspectRatio: posterPreviewAspect }}>
                       {imgUrl && (
                         <Image
                           src={imgUrl}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Spec 11 — PR-2 (Works horizontal scroll)

Depends on **PR #21** (`posterPreviewAspect` token).

### Changes
- `WorksScrollBlock`: all scroll item frames use `posterPreviewAspect` (`2/3`) instead of size-based 3/4, 2/3, 1/1
- Width sizing (large/medium/small) unchanged; gradient overlay unchanged

### Verification
- [x] `pnpm --filter @rfe/v0 typecheck`

**Base:** `cursor/poster-preview-constants-60d0` (merge PR-1 first)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c21b4afb-241d-4d4a-a066-55c5440660d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c21b4afb-241d-4d4a-a066-55c5440660d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

