### PR TITLE
fix: editable media name + live preview draft refresh

### DIFF
--- a/apps/rfe-v0/app/(frontend)/[locale]/[slug]/page.tsx
+++ b/apps/rfe-v0/app/(frontend)/[locale]/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import type { Language } from '@/lib/i18n/types'
 import { getPageBySlug, getAllPages, getSiteConfig } from '@/lib/cms'
 import { generatePageMeta, generatePageJsonLd } from '@/lib/generate-meta'
+import { LivePreviewListener } from '@/components/LivePreviewListener'
 import { PageContent } from '@/components/PageContent'
 
 type Props = {
@@ -43,6 +44,7 @@ export default async function DynamicPage({ params }: Props) {
 
   return (
     <main className="relative">
+      {draft.isEnabled && <LivePreviewListener />}
       <PageContent initialData={page} />
       {generatePageJsonLd(page, locale, siteConfig)}
     </main>

--- a/apps/rfe-v0/app/(frontend)/[locale]/page.tsx
+++ b/apps/rfe-v0/app/(frontend)/[locale]/page.tsx
@@ -3,6 +3,7 @@ import type { Language } from '@/lib/i18n/types'
 import { draftMode } from 'next/headers'
 import { getPageBySlug, getSiteConfig } from '@/lib/cms'
 import { generatePageMeta, generatePageJsonLd } from '@/lib/generate-meta'
+import { LivePreviewListener } from '@/components/LivePreviewListener'
 import { PageContent } from '@/components/PageContent'
 
 /** Home is not in `[slug]` static params; avoid caching an empty page before seed runs. */
@@ -39,6 +40,7 @@ export default async function HomePage({ params }: Props) {
 
   return (
     <main className="relative">
+      {draft.isEnabled && <LivePreviewListener />}
       <PageContent initialData={page} />
       {generatePageJsonLd(page, locale, siteConfig)}
     </main>

--- a/apps/rfe-v0/components/LivePreviewListener.tsx
+++ b/apps/rfe-v0/components/LivePreviewListener.tsx
@@ -3,14 +3,18 @@
 import { useRouter } from 'next/navigation'
 import { RefreshRouteOnSave } from '@payloadcms/live-preview-react'
 
+function getServerURL() {
+  // isDocumentEvent compares event.origin === serverURL (no trailing slash).
+  return (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(/\/$/, '')
+}
+
 export function LivePreviewListener() {
   const router = useRouter()
-  const serverURL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
   return (
     <RefreshRouteOnSave
       refresh={() => router.refresh()}
-      serverURL={serverURL}
+      serverURL={getServerURL()}
     />
   )
 }

--- a/apps/rfe-v0/components/PageContent.tsx
+++ b/apps/rfe-v0/components/PageContent.tsx
@@ -10,7 +10,11 @@ type Props = {
 }
 
 export function PageContent({ initialData }: Props) {
-  const serverURL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  // Origin match for postMessage — must not include a trailing slash.
+  const serverURL = (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(
+    /\/$/,
+    '',
+  )
 
   const { data: page } = useLivePreview<PageData>({
     initialData,

--- a/apps/rfe-v0/migrations/20260806_180000_media_title.ts
+++ b/apps/rfe-v0/migrations/20260806_180000_media_title.ts
@@ -1,0 +1,25 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media"
+      ADD COLUMN IF NOT EXISTS "title" varchar;
+  `)
+
+  // Backfill display names from existing filenames for admin usability.
+  await db.execute(sql`
+    UPDATE "media"
+    SET "title" = COALESCE(
+      NULLIF(trim(both FROM regexp_replace(regexp_replace("filename", '\\.[^.]+$', ''), '[-_]+', ' ', 'g')), ''),
+      "alt",
+      "filename"
+    )
+    WHERE "title" IS NULL;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "media" DROP COLUMN IF EXISTS "title";
+  `)
+}

--- a/apps/rfe-v0/migrations/index.ts
+++ b/apps/rfe-v0/migrations/index.ts
@@ -12,6 +12,7 @@ import * as migration_20260501_134738_image_position_select from './20260501_134
 import * as migration_20260611_000000_works_seen_on from './20260611_000000_works_seen_on';
 import * as migration_20260611_120000_site_config_secondary_email from './20260611_120000_site_config_secondary_email';
 import * as migration_20260626_120000_platforms_and_rich_description from './20260626_120000_platforms_and_rich_description';
+import * as migration_20260806_180000_media_title from './20260806_180000_media_title';
 
 export const migrations = [
   {
@@ -83,5 +84,10 @@ export const migrations = [
     up: migration_20260626_120000_platforms_and_rich_description.up,
     down: migration_20260626_120000_platforms_and_rich_description.down,
     name: '20260626_120000_platforms_and_rich_description',
+  },
+  {
+    up: migration_20260806_180000_media_title.up,
+    down: migration_20260806_180000_media_title.down,
+    name: '20260806_180000_media_title',
   },
 ];

--- a/apps/rfe-v0/payload-types.ts
+++ b/apps/rfe-v0/payload-types.ts
@@ -253,6 +253,10 @@ export interface Page {
  */
 export interface Media {
   id: number;
+  /**
+   * Display name in the admin panel. Does not change the stored filename.
+   */
+  title?: string | null;
   alt?: string | null;
   prefix?: string | null;
   updatedAt: string;
@@ -1578,6 +1582,7 @@ export interface UsersSelect<T extends boolean = true> {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
+  title?: T;
   alt?: T;
   prefix?: T;
   updatedAt?: T;

--- a/packages/cms/src/collections/Media.ts
+++ b/packages/cms/src/collections/Media.ts
@@ -4,6 +4,11 @@ import {
   revalidateSiteAfterDelete,
 } from '../utilities/cmsRevalidationHooks.ts'
 
+function titleFromFilename(filename: unknown): string | undefined {
+  if (typeof filename !== 'string' || !filename.trim()) return undefined
+  return filename.replace(/\.[^.]+$/, '').replace(/[-_]+/g, ' ').trim()
+}
+
 export const Media: CollectionConfig = {
   slug: 'media',
   access: {
@@ -11,8 +16,25 @@ export const Media: CollectionConfig = {
   },
   admin: {
     group: 'Admin',
+    useAsTitle: 'title',
+    defaultColumns: ['filename', 'title', 'alt', 'updatedAt'],
   },
   hooks: {
+    beforeChange: [
+      ({ data, originalDoc }) => {
+        if (!data) return data
+        // Keep an editable display name in sync when empty (create or legacy docs).
+        if (!data.title) {
+          data.title =
+            titleFromFilename(data.filename) ||
+            titleFromFilename(originalDoc?.filename) ||
+            data.alt ||
+            originalDoc?.alt ||
+            data.title
+        }
+        return data
+      },
+    ],
     afterChange: [revalidateSiteAfterChange],
     afterDelete: [revalidateSiteAfterDelete],
   },
@@ -46,6 +68,14 @@ export const Media: CollectionConfig = {
     mimeTypes: ['image/*'],
   },
   fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Name',
+      admin: {
+        description: 'Display name in the admin panel. Does not change the stored filename.',
+      },
+    },
     {
       name: 'alt',
       type: 'text',

--- a/packages/cms/src/collections/Pages.ts
+++ b/packages/cms/src/collections/Pages.ts
@@ -28,12 +28,14 @@ export const Pages: CollectionConfig = {
     defaultColumns: ['title', 'slug', 'updatedAt'],
     useAsTitle: 'title',
     livePreview: {
-      url: ({ data, req }) => {
-        const base = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-        const locale = req.locale || 'en'
-        const slug = typeof data?.slug === 'string' ? data.slug : ''
-        return slug === 'home' ? `${base}/${locale}` : `${base}/${locale}/${slug}`
-      },
+      // Route through /next/preview so draft mode is enabled — required for
+      // RefreshRouteOnSave to show unpublished (draft) changes in the iframe.
+      url: ({ data, req }) =>
+        generatePreviewPath({
+          slug: typeof data?.slug === 'string' ? data.slug : '',
+          collection: 'pages',
+          req,
+        }),
     },
     components: {
       views: {

--- a/packages/cms/src/components/LivePreview/index.tsx
+++ b/packages/cms/src/components/LivePreview/index.tsx
@@ -81,13 +81,20 @@ export const CustomLivePreview: React.FC = () => {
   } = useLivePreviewContext()
 
   const url = urlRaw ?? ''
+  // postMessage targetOrigin must be an origin (or URL whose origin is used).
+  // Preview URLs go through /next/preview?... — extract origin so draft redirects still match.
+  let targetOrigin = url
+  try {
+    if (url) targetOrigin = new URL(url).origin
+  } catch {
+    targetOrigin = url
+  }
 
   const locale = useLocale()
   const { mostRecentUpdate } = useDocumentEvents()
   const [formState] = useAllFormFields()
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
 
- 
   // ─── postMessage bridge (mirrors LivePreviewWindow exactly) ───────────────
   useEffect(() => {
     if (!isLivePreviewing || !appIsReady || !formState || !url) return
@@ -105,14 +112,15 @@ export const CustomLivePreview: React.FC = () => {
     }
 
     if (previewWindowType === 'popup' && popupRef?.current) {
-      popupRef.current.postMessage(message, url)
+      popupRef.current.postMessage(message, targetOrigin)
     }
     if (previewWindowType === 'iframe' && iframeRef.current) {
-      iframeRef.current.contentWindow?.postMessage(message, url)
+      iframeRef.current.contentWindow?.postMessage(message, targetOrigin)
     }
   }, [
     formState,
     url,
+    targetOrigin,
     collectionSlug,
     globalSlug,
     id,
@@ -126,17 +134,26 @@ export const CustomLivePreview: React.FC = () => {
     loadedURL,
   ])
 
-  // SSR refresh event
+  // SSR refresh on draft save / autosave / publish (via reportUpdate → mostRecentUpdate)
   useEffect(() => {
-    if (!isLivePreviewing || !appIsReady || !url) return
+    if (!isLivePreviewing || !appIsReady || !url || !mostRecentUpdate) return
     const message = { type: 'payload-document-event' }
     if (previewWindowType === 'popup' && popupRef?.current) {
-      popupRef.current.postMessage(message, url)
+      popupRef.current.postMessage(message, targetOrigin)
     }
     if (previewWindowType === 'iframe' && iframeRef.current) {
-      iframeRef.current.contentWindow?.postMessage(message, url)
+      iframeRef.current.contentWindow?.postMessage(message, targetOrigin)
     }
-  }, [mostRecentUpdate, iframeRef, popupRef, previewWindowType, url, isLivePreviewing, appIsReady])
+  }, [
+    mostRecentUpdate,
+    iframeRef,
+    popupRef,
+    previewWindowType,
+    url,
+    targetOrigin,
+    isLivePreviewing,
+    appIsReady,
+  ])
 
   // ─── Panel width + drag-to-resize ─────────────────────────────────────────
   const panelRef = useRef<HTMLDivElement>(null)

--- a/packages/cms/src/seed/seed-media.ts
+++ b/packages/cms/src/seed/seed-media.ts
@@ -150,16 +150,27 @@ export async function seedMedia(payload: Payload): Promise<Map<string, number>> 
     if (existing.docs.length > 0) {
       const doc = existing.docs[0]!
       mediaMap.set(imgPath, doc.id as number)
+      // Backfill display name when missing (safe to re-run).
+      if (!(doc as { title?: string | null }).title) {
+        const displayName = filename.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
+        await payload.update({
+          collection: 'media',
+          id: doc.id,
+          data: { title: displayName },
+        })
+      }
       console.log(`[seed-media] Already exists: ${filename}`)
       continue
     }
 
     const fileBuffer = fs.readFileSync(fullPath)
     try {
+      const displayName = filename.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
       const doc = await payload.create({
         collection: 'media',
         data: {
-          alt: filename.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' '),
+          title: displayName,
+          alt: displayName,
         },
         file: {
           data: fileBuffer,

--- a/packages/cms/src/utilities/generatePreviewPath.ts
+++ b/packages/cms/src/utilities/generatePreviewPath.ts
@@ -6,7 +6,7 @@ const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
 
 type Props = {
   collection: keyof typeof collectionPrefixMap
-  slug: string
+  slug: string | null | undefined
   req: PayloadRequest
   siteUrl?: string
 }
@@ -14,7 +14,7 @@ type Props = {
 export const generatePreviewPath = ({ collection, slug, req, siteUrl }: Props): string | null => {
   const { locale } = req
 
-  if (slug === undefined || slug === null) {
+  if (slug === undefined || slug === null || slug === '') {
     return null
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two admin UX issues:

1. **Media name not editable after upload** — Payload’s storage `filename` is read-only after upload by design. Added an editable **Name** (`title`) field used as `useAsTitle`, with migration backfill from existing filenames.
2. **Live preview not refreshing on draft save** — Embedded live preview loaded the public URL (no draft mode) and never mounted `LivePreviewListener`, so draft saves didn’t refresh unpublished content.

## Changes

- `Media` collection: `title` field (label: Name), `useAsTitle`, beforeChange defaulting, seed + migration backfill
- `Pages` `livePreview.url` now uses `generatePreviewPath` (enables draft mode via `/next/preview`)
- Mount `LivePreviewListener` on home + `[slug]` when draft mode is enabled
- Harden live-preview `postMessage` target origin + only emit document-events after real saves

## Test plan

- [ ] Upload a media item → open Edit → change **Name** → save → list/title updates
- [ ] Alt text still editable independently
- [ ] Open a Page → Live Preview → edit content → **Save draft** (do not publish) → iframe refreshes with draft changes
- [ ] Publish still works and shows published content on the public site
- [ ] Run migration `20260806_180000_media_title` (or app `onInit` auto-migrate) so existing media get titles

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

