### PR TITLE
fix: media title migration — alt is on media_locales

### DIFF
--- a/apps/rfe-v0/migrations/20260806_180000_media_title.ts
+++ b/apps/rfe-v0/migrations/20260806_180000_media_title.ts
@@ -6,15 +6,24 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
       ADD COLUMN IF NOT EXISTS "title" varchar;
   `)
 
-  // Backfill display names from existing filenames for admin usability.
+  // `alt` is localized on media_locales — not a column on media.
   await db.execute(sql`
-    UPDATE "media"
+    UPDATE "media" AS m
     SET "title" = COALESCE(
-      NULLIF(trim(both FROM regexp_replace(regexp_replace("filename", '\\.[^.]+$', ''), '[-_]+', ' ', 'g')), ''),
-      "alt",
-      "filename"
+      NULLIF(
+        trim(both FROM regexp_replace(regexp_replace(COALESCE(m."filename", ''), '\\.[^.]+$', ''), '[-_]+', ' ', 'g')),
+        ''
+      ),
+      (
+        SELECT ml."alt"
+        FROM "media_locales" AS ml
+        WHERE ml."_parent_id" = m."id"
+        ORDER BY ml."_locale" ASC
+        LIMIT 1
+      ),
+      m."filename"
     )
-    WHERE "title" IS NULL;
+    WHERE m."title" IS NULL;
   `)
 }
 

--- a/apps/rfe-v0/migrations/20260806_180000_media_title.ts
+++ b/apps/rfe-v0/migrations/20260806_180000_media_title.ts
@@ -1,33 +1,43 @@
 import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 
+/**
+ * Production-safe / additive-only:
+ * - Adds nullable `media.title` if missing (no rewrite of existing columns)
+ * - Backfills ONLY rows where title IS NULL
+ * - Never touches filename, urls, sizes, S3 objects, or media_locales.alt
+ * - Never deletes rows
+ *
+ * Safe to re-run after the failed deploy: ADD COLUMN IF NOT EXISTS no-ops if
+ * the column already exists; UPDATE is guarded by WHERE title IS NULL.
+ */
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
     ALTER TABLE "media"
       ADD COLUMN IF NOT EXISTS "title" varchar;
   `)
 
-  // `alt` is localized on media_locales — not a column on media.
+  // Filename-only backfill — do not join locales (avoids localized-column pitfalls).
+  // Empty/null filename → leave title null; Media.beforeChange fills on next edit.
   await db.execute(sql`
-    UPDATE "media" AS m
-    SET "title" = COALESCE(
-      NULLIF(
-        trim(both FROM regexp_replace(regexp_replace(COALESCE(m."filename", ''), '\\.[^.]+$', ''), '[-_]+', ' ', 'g')),
-        ''
+    UPDATE "media"
+    SET "title" = NULLIF(
+      trim(
+        both FROM regexp_replace(
+          regexp_replace(COALESCE("filename", ''), '\\.[^.]+$', ''),
+          '[-_]+',
+          ' ',
+          'g'
+        )
       ),
-      (
-        SELECT ml."alt"
-        FROM "media_locales" AS ml
-        WHERE ml."_parent_id" = m."id"
-        ORDER BY ml."_locale" ASC
-        LIMIT 1
-      ),
-      m."filename"
+      ''
     )
-    WHERE m."title" IS NULL;
+    WHERE "title" IS NULL
+      AND "filename" IS NOT NULL;
   `)
 }
 
 export async function down({ db }: MigrateDownArgs): Promise<void> {
+  // Do NOT run in production. Drops only the additive title column.
   await db.execute(sql`
     ALTER TABLE "media" DROP COLUMN IF EXISTS "title";
   `)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failed production migration from #26 without risking data loss.

## Why the deploy failed

`alt` is localized → lives on `media_locales`, not `media`. The backfill referenced `media.alt` and aborted.

## Production safety

This migration is **additive-only**:

| Operation | Effect |
|---|---|
| `ADD COLUMN IF NOT EXISTS title` | Adds a nullable column; no existing columns/rows changed |
| `UPDATE … WHERE title IS NULL` | Fills display names only for rows that have no title yet |
| Filenames / URLs / sizes / S3 | **Untouched** |
| `media_locales.alt` | **Untouched** |
| Deletes / drops / truncates | **None** in `up` |

### About the failed Vercel build

It connected to the DB during build and errored on the UPDATE. In PostgreSQL that statement fails at planning time (unknown column), so **no media rows were updated**. Worst case already applied: a nullable empty `title` column — harmless to the running site. Re-deploying this fix is safe to re-run (`IF NOT EXISTS` + `WHERE title IS NULL`).

**Do not run `migrate:down` in production** (down only drops `title`).

## Test plan

- [ ] Deploy this PR
- [ ] Confirm build/migration succeeds
- [ ] Spot-check media in admin: files, alts, and URLs unchanged; Name populated from filename where empty

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

