### PR TITLE
fix: embedded live preview live-reload (same-origin bridge)

### DIFF
--- a/apps/rfe-v0/components/LivePreviewListener.tsx
+++ b/apps/rfe-v0/components/LivePreviewListener.tsx
@@ -2,11 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { RefreshRouteOnSave } from '@payloadcms/live-preview-react'
-
-function getServerURL() {
-  // isDocumentEvent compares event.origin === serverURL (no trailing slash).
-  return (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(/\/$/, '')
-}
+import { getLivePreviewServerURL } from '@/lib/live-preview'
 
 export function LivePreviewListener() {
   const router = useRouter()
@@ -14,7 +10,7 @@ export function LivePreviewListener() {
   return (
     <RefreshRouteOnSave
       refresh={() => router.refresh()}
-      serverURL={getServerURL()}
+      serverURL={getLivePreviewServerURL()}
     />
   )
 }

--- a/apps/rfe-v0/components/PageContent.tsx
+++ b/apps/rfe-v0/components/PageContent.tsx
@@ -3,6 +3,7 @@
 import { useLivePreview } from '@payloadcms/live-preview-react'
 import { RenderHero } from '@/components/blocks/RenderHero'
 import { RenderBlocks } from '@/components/blocks/RenderBlocks'
+import { getLivePreviewServerURL } from '@/lib/live-preview'
 import type { PageData } from '@/lib/cms'
 
 type Props = {
@@ -10,15 +11,9 @@ type Props = {
 }
 
 export function PageContent({ initialData }: Props) {
-  // Origin match for postMessage — must not include a trailing slash.
-  const serverURL = (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(
-    /\/$/,
-    '',
-  )
-
   const { data: page } = useLivePreview<PageData>({
     initialData,
-    serverURL,
+    serverURL: getLivePreviewServerURL(),
     depth: 2,
   })
 

--- a/apps/rfe-v0/lib/live-preview.ts
+++ b/apps/rfe-v0/lib/live-preview.ts
@@ -1,0 +1,12 @@
+/**
+ * Origin used for Payload live-preview postMessage checks.
+ * Must match `event.origin` from the admin parent / iframe peer.
+ * Prefer the actual browser origin over NEXT_PUBLIC_SITE_URL so www/apex
+ * or deployment-host mismatches do not silently break live reload.
+ */
+export function getLivePreviewServerURL(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+  return (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(/\/$/, '')
+}

--- a/packages/cms/src/components/LivePreview/index.tsx
+++ b/packages/cms/src/components/LivePreview/index.tsx
@@ -6,7 +6,7 @@ import { useDocumentInfo } from '@payloadcms/ui'
 import { useLivePreviewContext } from '@payloadcms/ui'
 import { useLocale } from '@payloadcms/ui'
 import { reduceFieldsToValues } from 'payload/shared'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const INSET_PX = 16
 const HANDLE_PX = 6
@@ -14,15 +14,28 @@ const MIN_PANEL_PX = 300
 const MIN_FORM_PX = 280
 const DEFAULT_PANEL_PX = 500
 
+function getPostMessageTargetOrigin(previewURL: string): string {
+  // Always prefer the admin's own origin so iframe messaging stays same-origin,
+  // even if the configured preview URL was built with a different SITE_URL host.
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+  try {
+    if (previewURL) return new URL(previewURL, 'http://localhost').origin
+  } catch {
+    // fall through
+  }
+  return previewURL || '*'
+}
+
 // ─── Breakpoint selector ─────────────────────────────────────────────────────
 
 const BreakpointBar: React.FC = () => {
   const { breakpoint, breakpoints, setBreakpoint } = useLivePreviewContext()
 
-
   useEffect(() => {
     setBreakpoint('mobile')
-  }, [])
+  }, [setBreakpoint])
 
   const allBreakpoints = [
     { label: 'Responsive', name: 'responsive' },
@@ -81,79 +94,60 @@ export const CustomLivePreview: React.FC = () => {
   } = useLivePreviewContext()
 
   const url = urlRaw ?? ''
-  // postMessage targetOrigin must be an origin (or URL whose origin is used).
-  // Preview URLs go through /next/preview?... — extract origin so draft redirects still match.
-  let targetOrigin = url
-  try {
-    if (url) targetOrigin = new URL(url).origin
-  } catch {
-    targetOrigin = url
-  }
+  const targetOrigin = useMemo(() => getPostMessageTargetOrigin(url), [url])
 
   const locale = useLocale()
   const { mostRecentUpdate } = useDocumentEvents()
   const [formState] = useAllFormFields()
   const { id, collectionSlug, globalSlug } = useDocumentInfo()
 
-  // ─── postMessage bridge (mirrors LivePreviewWindow exactly) ───────────────
+  const postToPreview = useCallback(
+    (message: Record<string, unknown>) => {
+      if (!url) return
+      if (previewWindowType === 'popup' && popupRef?.current) {
+        popupRef.current.postMessage(message, targetOrigin)
+      }
+      if (previewWindowType === 'iframe' && iframeRef.current?.contentWindow) {
+        iframeRef.current.contentWindow.postMessage(message, targetOrigin)
+      }
+    },
+    [url, previewWindowType, popupRef, iframeRef, targetOrigin],
+  )
+
+  // ─── postMessage bridge (mirrors LivePreviewWindow) ───────────────────────
   useEffect(() => {
     if (!isLivePreviewing || !appIsReady || !formState || !url) return
 
     const values = reduceFieldsToValues(formState, true)
     if (!values.id) values.id = id
 
-    const message = {
+    postToPreview({
       collectionSlug,
       data: values,
       externallyUpdatedRelationship: mostRecentUpdate,
       globalSlug,
       locale: locale.code,
       type: 'payload-live-preview',
-    }
-
-    if (previewWindowType === 'popup' && popupRef?.current) {
-      popupRef.current.postMessage(message, targetOrigin)
-    }
-    if (previewWindowType === 'iframe' && iframeRef.current) {
-      iframeRef.current.contentWindow?.postMessage(message, targetOrigin)
-    }
+    })
   }, [
     formState,
     url,
-    targetOrigin,
     collectionSlug,
     globalSlug,
     id,
-    previewWindowType,
-    popupRef,
     appIsReady,
-    iframeRef,
     mostRecentUpdate,
     locale,
     isLivePreviewing,
     loadedURL,
+    postToPreview,
   ])
 
-  // SSR refresh on draft save / autosave / publish (via reportUpdate → mostRecentUpdate)
+  // SSR refresh on draft save / autosave / publish (reportUpdate → mostRecentUpdate)
   useEffect(() => {
     if (!isLivePreviewing || !appIsReady || !url || !mostRecentUpdate) return
-    const message = { type: 'payload-document-event' }
-    if (previewWindowType === 'popup' && popupRef?.current) {
-      popupRef.current.postMessage(message, targetOrigin)
-    }
-    if (previewWindowType === 'iframe' && iframeRef.current) {
-      iframeRef.current.contentWindow?.postMessage(message, targetOrigin)
-    }
-  }, [
-    mostRecentUpdate,
-    iframeRef,
-    popupRef,
-    previewWindowType,
-    url,
-    targetOrigin,
-    isLivePreviewing,
-    appIsReady,
-  ])
+    postToPreview({ type: 'payload-document-event' })
+  }, [mostRecentUpdate, url, isLivePreviewing, appIsReady, postToPreview])
 
   // ─── Panel width + drag-to-resize ─────────────────────────────────────────
   const panelRef = useRef<HTMLDivElement>(null)
@@ -178,7 +172,6 @@ export const CustomLivePreview: React.FC = () => {
     setPanelWidth(Math.max(MIN_PANEL_PX, ideal))
   }, [deviceW])
 
-  // Drag handle mouse events
   const onHandleMouseDown = useCallback((e: React.MouseEvent) => {
     isDragging.current = true
     dragStartX.current = e.clientX
@@ -193,7 +186,6 @@ export const CustomLivePreview: React.FC = () => {
       if (!isDragging.current || !panelRef.current) return
       const parent = panelRef.current.parentElement
       const maxW = parent ? parent.clientWidth - MIN_FORM_PX - HANDLE_PX : 1200
-      // dragging left (lower clientX) → panel grows
       const delta = dragStartX.current - e.clientX
       const newWidth = Math.max(MIN_PANEL_PX, Math.min(dragStartWidth.current + delta, maxW))
       setPanelWidth(newWidth)
@@ -271,7 +263,6 @@ export const CustomLivePreview: React.FC = () => {
         width: panelWidth,
       }}
     >
-      {/* Drag handle on the left edge */}
       <div
         onMouseDown={onHandleMouseDown}
         style={{
@@ -293,7 +284,6 @@ export const CustomLivePreview: React.FC = () => {
         }}
       />
 
-      {/* Content offset by handle width */}
       <div style={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden', paddingLeft: HANDLE_PX }}>
         <BreakpointBar />
 

--- a/packages/cms/src/utilities/generatePreviewPath.ts
+++ b/packages/cms/src/utilities/generatePreviewPath.ts
@@ -8,9 +8,18 @@ type Props = {
   collection: keyof typeof collectionPrefixMap
   slug: string | null | undefined
   req: PayloadRequest
+  /** Optional absolute origin. Prefer omitting so the URL stays same-origin with the admin. */
   siteUrl?: string
 }
 
+/**
+ * Preview / live-preview entry URL.
+ *
+ * Returns a **relative** `/next/preview?...` path by default. Payload's admin
+ * `formatAbsoluteURL` resolves it against `window.location.origin`, which keeps
+ * the embedded iframe same-origin with the admin panel. That is required for
+ * `postMessage` + `ready` live-preview to work (strict origin checks).
+ */
 export const generatePreviewPath = ({ collection, slug, req, siteUrl }: Props): string | null => {
   const { locale } = req
 
@@ -18,12 +27,12 @@ export const generatePreviewPath = ({ collection, slug, req, siteUrl }: Props): 
     return null
   }
 
-  const base = siteUrl || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   const encodedSlug = encodeURIComponent(slug)
   const prefix = collectionPrefixMap[collection] ?? ''
-  const pagePath = slug === 'home'
-    ? `/${locale || 'en'}`
-    : `/${locale || 'en'}${prefix ? `/${prefix}` : ''}/${encodedSlug}`
+  const pagePath =
+    slug === 'home'
+      ? `/${locale || 'en'}`
+      : `/${locale || 'en'}${prefix ? `/${prefix}` : ''}/${encodedSlug}`
 
   const params = new URLSearchParams({
     slug: encodedSlug,
@@ -33,5 +42,9 @@ export const generatePreviewPath = ({ collection, slug, req, siteUrl }: Props): 
     previewSecret: process.env.PREVIEW_SECRET || '',
   })
 
-  return `${base}/next/preview?${params.toString()}`
+  const path = `/next/preview?${params.toString()}`
+  if (siteUrl) {
+    return `${siteUrl.replace(/\/$/, '')}${path}`
+  }
+  return path
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The custom embedded Live Preview (mobile default) was not live-reloading because Payload’s preview bridge uses **strict `postMessage` origin checks**. We were building the iframe URL and `serverURL` from `NEXT_PUBLIC_SITE_URL`, which often differs from the actual admin host (www vs apex, custom domain vs deployment URL). When origins don’t match:

1. iframe `ready` never reaches the admin → `appIsReady` stays false  
2. form updates are never posted → no live reload

## Fix

- `generatePreviewPath` returns a **relative** `/next/preview?...` URL (Payload resolves it against `window.location.origin`)
- Frontend `useLivePreview` / `RefreshRouteOnSave` use `window.location.origin`
- Custom Live Preview posts to the iframe with `window.location.origin`

No schema/data changes.

## Test plan

- [ ] Admin → Pages → enable Live Preview (mobile)
- [ ] Edit a text field → iframe updates without publishing
- [ ] Save draft → iframe still reflects draft changes
- [ ] Breakpoint switch (mobile/tablet/desktop) still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

