### PR TITLE
feat(admin): Media list shows Name + thumbnail (not filename)

### DIFF
--- a/apps/rfe-v0/app/(payload)/admin/importMap.js
+++ b/apps/rfe-v0/app/(payload)/admin/importMap.js
@@ -29,6 +29,7 @@ import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { CustomLivePreview as CustomLivePreview_0570d7a137ba4b854d50588a1e1ee968 } from '@rfe/cms/components/LivePreview'
 import { SlugField as SlugField_20048c6163b175d3db4ad5fb0a36a7e8 } from '@rfe/cms/components/SlugField'
+import { MediaTitleCell as MediaTitleCell_5cfb0885778deefed5fb899582dd4970 } from '@rfe/cms/components/MediaTitleCell'
 import { ColorPickerField as ColorPickerField_aa22b64f10c5e420411c7f67ce2bd4ac } from '@rfe/cms/fields/client'
 import { Icon as Icon_30f9b97464cd6aed523463ee2909896b } from '@rfe/cms/components/Icon'
 import { Logo as Logo_3ca2ef1bfffa22c2c98fe79e696bd43a } from '@rfe/cms/components/Logo'
@@ -69,6 +70,7 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@rfe/cms/components/LivePreview#CustomLivePreview": CustomLivePreview_0570d7a137ba4b854d50588a1e1ee968,
   "@rfe/cms/components/SlugField#SlugField": SlugField_20048c6163b175d3db4ad5fb0a36a7e8,
+  "@rfe/cms/components/MediaTitleCell#MediaTitleCell": MediaTitleCell_5cfb0885778deefed5fb899582dd4970,
   "@rfe/cms/fields/client#ColorPickerField": ColorPickerField_aa22b64f10c5e420411c7f67ce2bd4ac,
   "@rfe/cms/components/Icon#Icon": Icon_30f9b97464cd6aed523463ee2909896b,
   "@rfe/cms/components/Logo#Logo": Logo_3ca2ef1bfffa22c2c98fe79e696bd43a,

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -52,6 +52,10 @@
       "types": "./src/components/SlugField/index.tsx",
       "default": "./src/components/SlugField/index.tsx"
     },
+    "./components/MediaTitleCell": {
+      "types": "./src/components/MediaTitleCell/index.tsx",
+      "default": "./src/components/MediaTitleCell/index.tsx"
+    },
     "./fields/client": {
       "types": "./src/fields/client.ts",
       "default": "./src/fields/client.ts"

--- a/packages/cms/src/collections/Media.ts
+++ b/packages/cms/src/collections/Media.ts
@@ -17,7 +17,9 @@ export const Media: CollectionConfig = {
   admin: {
     group: 'Admin',
     useAsTitle: 'title',
-    defaultColumns: ['filename', 'title', 'alt', 'updatedAt'],
+    // Thumbnail + Name first; File Name available via Columns picker.
+    defaultColumns: ['title', 'alt', 'updatedAt'],
+    listSearchableFields: ['title', 'filename', 'alt'],
   },
   hooks: {
     beforeChange: [
@@ -39,6 +41,7 @@ export const Media: CollectionConfig = {
     afterDelete: [revalidateSiteAfterDelete],
   },
   upload: {
+    adminThumbnail: 'thumbnail',
     imageSizes: [
       {
         name: 'thumbnail',
@@ -74,6 +77,9 @@ export const Media: CollectionConfig = {
       label: 'Name',
       admin: {
         description: 'Display name in the admin panel. Does not change the stored filename.',
+        components: {
+          Cell: '@rfe/cms/components/MediaTitleCell#MediaTitleCell',
+        },
       },
     },
     {

--- a/packages/cms/src/components/MediaTitleCell/index.tsx
+++ b/packages/cms/src/components/MediaTitleCell/index.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import React from 'react'
+import { Thumbnail } from '@payloadcms/ui'
+import { getBestFitFromSizes, isImage } from 'payload/shared'
+import type { SanitizedCollectionConfig } from 'payload'
+
+type Props = {
+  cellData?: unknown
+  collectionSlug?: string
+  rowData?: Record<string, unknown>
+  collectionConfig?: SanitizedCollectionConfig
+}
+
+/**
+ * List cell: thumbnail + Name (title), mirroring Payload's filename FileCell
+ * so the media list can lead with the human-readable name instead of the storage filename.
+ */
+export const MediaTitleCell: React.FC<Props> = ({
+  cellData,
+  collectionConfig,
+  collectionSlug,
+  rowData = {},
+}) => {
+  const filename = typeof rowData.filename === 'string' ? rowData.filename : null
+  const label =
+    (typeof cellData === 'string' && cellData.trim()) || filename || 'Untitled'
+
+  const previewAllowed = collectionConfig?.upload?.displayPreview ?? true
+  if (!previewAllowed) {
+    return <>{String(label)}</>
+  }
+
+  const mimeType = typeof rowData.mimeType === 'string' ? rowData.mimeType : ''
+  const thumbnailURL = typeof rowData.thumbnailURL === 'string' ? rowData.thumbnailURL : undefined
+  const url = typeof rowData.url === 'string' ? rowData.url : undefined
+  const width = typeof rowData.width === 'number' ? rowData.width : undefined
+  const updatedAt = typeof rowData.updatedAt === 'string' ? rowData.updatedAt : undefined
+
+  const isFileImage = isImage(mimeType)
+  let fileSrc = isFileImage ? thumbnailURL || url : thumbnailURL
+
+  if (isFileImage) {
+    fileSrc = getBestFitFromSizes({
+      sizes: rowData.sizes as Parameters<typeof getBestFitFromSizes>[0]['sizes'],
+      thumbnailURL,
+      url: url ?? '',
+      width,
+    })
+  }
+
+  return (
+    <div className="file">
+      <Thumbnail
+        className="file__thumbnail"
+        collectionSlug={collectionConfig?.slug || collectionSlug}
+        doc={{
+          ...rowData,
+          filename,
+        }}
+        fileSrc={fileSrc}
+        imageCacheTag={collectionConfig?.upload?.cacheTags && updatedAt ? updatedAt : undefined}
+        size="small"
+        uploadConfig={collectionConfig?.upload}
+      />
+      <span className="file__filename">{String(label)}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Media list was showing **File Name + thumbnail** because Payload hardcodes the thumbnail cell on the `filename` column.

## Change

- Custom **Name** list cell (`MediaTitleCell`) renders thumbnail + title
- Default columns: `Name`, `Alt`, `Updated At`
- **File Name** remains available via **Columns** (not shown by default)
- Search still covers name / filename / alt

## Test plan

- [ ] Admin → Media list shows thumbnail next to Name
- [ ] File Name column is hidden by default
- [ ] Columns picker can re-enable File Name
- [ ] Search by Name still finds items

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

