### PR TITLE
fix(admin): restore Media list edit link on Name cell

### DIFF
--- a/packages/cms/src/components/MediaTitleCell/index.tsx
+++ b/packages/cms/src/components/MediaTitleCell/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import React from 'react'
-import { Thumbnail } from '@payloadcms/ui'
-import { getBestFitFromSizes, isImage } from 'payload/shared'
+import { Link, Thumbnail, useConfig } from '@payloadcms/ui'
+import { formatAdminURL, getBestFitFromSizes, isImage } from 'payload/shared'
 import type { SanitizedCollectionConfig } from 'payload'
 
 type Props = {
@@ -10,26 +10,37 @@ type Props = {
   collectionSlug?: string
   rowData?: Record<string, unknown>
   collectionConfig?: SanitizedCollectionConfig
+  /** When true, this is the linked column — wrap content in the edit URL. */
+  link?: boolean
+  linkURL?: string
+  viewType?: 'default' | 'trash' | string
 }
 
 /**
  * List cell: thumbnail + Name (title), mirroring Payload's filename FileCell
  * so the media list can lead with the human-readable name instead of the storage filename.
+ *
+ * Custom Cells replace DefaultCell entirely, so they must render the edit link themselves.
  */
 export const MediaTitleCell: React.FC<Props> = ({
   cellData,
   collectionConfig,
   collectionSlug,
+  link,
+  linkURL,
   rowData = {},
+  viewType,
 }) => {
+  const {
+    config: {
+      routes: { admin: adminRoute },
+    },
+  } = useConfig()
+
   const filename = typeof rowData.filename === 'string' ? rowData.filename : null
+  const id = rowData.id != null ? String(rowData.id) : ''
   const label =
     (typeof cellData === 'string' && cellData.trim()) || filename || 'Untitled'
-
-  const previewAllowed = collectionConfig?.upload?.displayPreview ?? true
-  if (!previewAllowed) {
-    return <>{String(label)}</>
-  }
 
   const mimeType = typeof rowData.mimeType === 'string' ? rowData.mimeType : ''
   const thumbnailURL = typeof rowData.thumbnailURL === 'string' ? rowData.thumbnailURL : undefined
@@ -37,10 +48,11 @@ export const MediaTitleCell: React.FC<Props> = ({
   const width = typeof rowData.width === 'number' ? rowData.width : undefined
   const updatedAt = typeof rowData.updatedAt === 'string' ? rowData.updatedAt : undefined
 
+  const previewAllowed = collectionConfig?.upload?.displayPreview ?? true
   const isFileImage = isImage(mimeType)
   let fileSrc = isFileImage ? thumbnailURL || url : thumbnailURL
 
-  if (isFileImage) {
+  if (previewAllowed && isFileImage) {
     fileSrc = getBestFitFromSizes({
       sizes: rowData.sizes as Parameters<typeof getBestFitFromSizes>[0]['sizes'],
       thumbnailURL,
@@ -49,7 +61,7 @@ export const MediaTitleCell: React.FC<Props> = ({
     })
   }
 
-  return (
+  const content = previewAllowed ? (
     <div className="file">
       <Thumbnail
         className="file__thumbnail"
@@ -65,5 +77,30 @@ export const MediaTitleCell: React.FC<Props> = ({
       />
       <span className="file__filename">{String(label)}</span>
     </div>
+  ) : (
+    <>{String(label)}</>
+  )
+
+  if (!link) {
+    return content
+  }
+
+  const href =
+    linkURL ||
+    (collectionSlug && id
+      ? formatAdminURL({
+          adminRoute,
+          path: `/collections/${collectionSlug}${viewType === 'trash' ? '/trash' : ''}/${encodeURIComponent(id)}`,
+        })
+      : '')
+
+  if (!href) {
+    return content
+  }
+
+  return (
+    <Link href={href} prefetch={false}>
+      {content}
+    </Link>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After switching the Media list to show **Name + thumbnail**, the edit link disappeared because custom Cells replace Payload’s `DefaultCell`, which normally wraps the linked column.

## Fix

`MediaTitleCell` now wraps itself in the document edit `Link` when it is the linked column (same behavior as the old filename cell).

## Test plan

- [ ] Admin → Media → click Name or thumbnail → opens edit view

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cba5bf36-467c-4138-8b8d-9d21c3c6a008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

